### PR TITLE
remove second header from the about page

### DIFF
--- a/src/components/AboutUs.jsx
+++ b/src/components/AboutUs.jsx
@@ -3,12 +3,7 @@ import React from 'react'
 const AboutUs = () => {
     return (
         <div className='bg-[url(/pic.png)] sm:bg-[url(/backgroundImg.png)] bg-cover bg-center h-screen w-screen bg-fixed overflow-auto'>
-            {/* Header */}
-            <header className="bg-[#2D2822] text-white py-4">
-                <div className="container mx-auto px-4">
-                    <h1 className="text-3xl font-bold">Emulation Club</h1>
-                </div>
-            </header>
+            
 
             {/* Main Content */}
             <main className="container mx-auto px-4 py-8">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/129aa207-3165-49e8-a864-b00ec3b026c3)
   just remove the second header it is not good to add  two nav and fixes some Ui work 